### PR TITLE
fix LABEL language neologism

### DIFF
--- a/app/src/main/java/io/atha/bababasic/ActivityMain.kt
+++ b/app/src/main/java/io/atha/bababasic/ActivityMain.kt
@@ -453,7 +453,7 @@ NEXT I%
         "INKEY.bas" to """PRINT "PRESS w,a,s,d TO MOVE THE STAR. PRESS q to QUIT."
 X = 5
 Y = 5
-LABEL "event_loop"
+eventLoop:
 LOCATE 2
 FOR I = 0 TO 10
 FOR J = 0 TO 10
@@ -475,7 +475,7 @@ IF X < 0 THEN X = 0
 IF X > 10 THEN X = 10
 IF Y < 0 THEN Y = 0
 IF Y > 10 THEN Y = 10
-GOTO "event_loop""""
+GOTO eventLoop"""
     )
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/libbababasic/src/main/antlr/io/atha/libbababasic/grammar/BabaBASIC.g4
+++ b/libbababasic/src/main/antlr/io/atha/libbababasic/grammar/BabaBASIC.g4
@@ -9,11 +9,15 @@ prog
     ;
 
 line
-    : linenum? stmtlist? comment? NEWLINE
+    : (linenum? stmtlist? comment?|linelabel) NEWLINE
     ;
 
 linenum
     : DECIMAL
+    ;
+
+linelabel
+    : name=VARNAME COLON
     ;
 
 comment
@@ -108,7 +112,6 @@ stmt
     | playwavstmt
     | stopwavstmt
     | loopwavstmt
-    | labelstmt
     | liststmt
     | dictstmt
     | setstmt
@@ -256,7 +259,7 @@ gosubstmt
     ;
 
 gosublabelstmt
-    : GOSUB string
+    : GOSUB name=VARNAME
     ;
 
 returnstmt
@@ -324,7 +327,7 @@ endifstmt
     ;
 
 stmtlist
-    : stmt (':' stmt)*
+    : stmt (COLON stmt)*
     ;
 
 forstmt
@@ -340,7 +343,7 @@ gotostmt
     ;
 
 gotolabelstmt
-    : GOTO string
+    : GOTO name=VARNAME
     ;
 
 endstmt
@@ -620,10 +623,6 @@ stopwavstmt
 
 loopwavstmt
     : LOOPWAV variable
-    ;
-
-labelstmt
-    : LABEL name=string
     ;
 
 liststmt
@@ -1311,10 +1310,6 @@ HSB2RGB
     : H S B '2' R G B
     ;
 
-LABEL
-    : L A B E L
-    ;
-
 BEGIN
     : B E G I N
     ;
@@ -1381,6 +1376,10 @@ STRING
 
 COMMA
     : ','
+    ;
+
+COLON
+    : ':'
     ;
 
 SEMICOLON

--- a/libbababasic/src/main/java/io/atha/libbababasic/domain/SymbolTable.kt
+++ b/libbababasic/src/main/java/io/atha/libbababasic/domain/SymbolTable.kt
@@ -131,10 +131,10 @@ class SymbolTable {
     }
 
     fun addLabel(label: String): Int {
-        var id: Int = labelNameToId.getOrDefault(label, -1)
+        var id: Int = labelNameToId.getOrDefault(label.toLowerCase(), -1)
         if (id == -1) {
             id = addLabel()
-            labelNameToId[label] = id
+            labelNameToId[label.toLowerCase()] = id
         }
         return id
     }

--- a/libbababasic/src/main/java/io/atha/libbababasic/parser/IRListener.kt
+++ b/libbababasic/src/main/java/io/atha/libbababasic/parser/IRListener.kt
@@ -175,7 +175,6 @@ import io.atha.libbababasic.grammar.BabaBASICParser.IfthenbeginstmtContext
 import io.atha.libbababasic.grammar.BabaBASICParser.ImportstmtContext
 import io.atha.libbababasic.grammar.BabaBASICParser.InputhashstmtContext
 import io.atha.libbababasic.grammar.BabaBASICParser.InputstmtContext
-import io.atha.libbababasic.grammar.BabaBASICParser.LabelstmtContext
 import io.atha.libbababasic.grammar.BabaBASICParser.LeafvariableContext
 import io.atha.libbababasic.grammar.BabaBASICParser.LetstmtContext
 import io.atha.libbababasic.grammar.BabaBASICParser.LineContext
@@ -3485,7 +3484,7 @@ class IRListener(
     }
 
     override fun exitGosublabelstmt(ctx: GosublabelstmtContext) {
-        val gotoLabel = ir.symbolTable.addLabel(ctx.string().STRING().text)
+        val gotoLabel = ir.symbolTable.addLabel(ctx.VARNAME().text)
         val pushReturnLabel = ir.addInstruction(
             sourceFile,
             currentLineNumber,
@@ -3547,7 +3546,7 @@ class IRListener(
     }
 
     override fun exitGotolabelstmt(ctx: GotolabelstmtContext) {
-        val gotoLabel = ir.symbolTable.addLabel(ctx.string().STRING().text)
+        val gotoLabel = ir.symbolTable.addLabel(ctx.VARNAME().text)
         ir.addInstruction(
             sourceFile,
             currentLineNumber,
@@ -4197,8 +4196,8 @@ class IRListener(
         }
     }
 
-    override fun exitLabelstmt(ctx: LabelstmtContext) {
-        val label = ctx.string().STRING().text
+    override fun exitLinelabel(ctx: BabaBASICParser.LinelabelContext) {
+        val label = ctx.VARNAME().text
         ir.addInstruction(
             sourceFile,
             currentLineNumber,

--- a/libbababasic/src/test/kotlin/io/atha/libbababasic/IntegrationTest.kt
+++ b/libbababasic/src/test/kotlin/io/atha/libbababasic/IntegrationTest.kt
@@ -81,6 +81,9 @@ class IntegrationTest {
     fun testGosublabel() = runTest("gosublabel.bas", "gosublabel.bas.output")
 
     @Test fun testGotoLabel() = runTest("gotolabel.bas", "gotolabel.bas.output")
+
+    @Test fun testGotoLabelCaseInsensitive() = runTest("gotolabel_case_insensitive.bas", "gotolabel.bas.output")
+
     @Test
     fun testDef() = runTest("def.bas", "def.bas.output")
     @Test

--- a/libbababasic/src/test/resources/gotolabel.bas
+++ b/libbababasic/src/test/resources/gotolabel.bas
@@ -1,5 +1,5 @@
 PRINT "A"
-GOTO "label1"
+GOTO label1
 END
-LABEL "label1"
+label1:
 PRINT "label1"

--- a/libbababasic/src/test/resources/gotolabel_case_insensitive.bas
+++ b/libbababasic/src/test/resources/gotolabel_case_insensitive.bas
@@ -1,0 +1,5 @@
+PRINT "A"
+GOTO LAbel1
+END
+LaBeL1:
+PRINT "label1"


### PR DESCRIPTION
LABELs in QuickBasic are declared as `labelNameHere:`, not as `LABEL "label_name_here"`.