### PR TITLE
feat: use UTF-8 to represent strings

### DIFF
--- a/app/src/main/java/io/atha/bababasic/ActivityMain.kt
+++ b/app/src/main/java/io/atha/bababasic/ActivityMain.kt
@@ -415,10 +415,6 @@ class ActivityMain : AppCompatActivity() {
         super.onPause()
     }
 
-    private val defaultScript = "10 PRINT \"HELLO WORLD\"\n" +
-            "20 INPUT \"Name? \", A$\n" +
-            "30 PRINT \"HELLO \" + A$\n"
-
     override fun onResume() {
         super.onResume()
         val sharedPref = getPreferences(Context.MODE_PRIVATE)!!
@@ -428,7 +424,11 @@ class ActivityMain : AppCompatActivity() {
     }
 
     private val EXAMPLES = mapOf(
-        "HELLO.bas" to """10 PRINT "HELLO WORLD"
+        "HELLO.bas" to """PRINT "HELLO WORLD"
+PRINT "Καλημέρα κόσμε"
+PRINT "ハローワールド"
+INPUT "Name? ", A$
+PRINT "HELLO " + A$
 """,
         "PRIME.bas" to """FOR I% = 1 TO 10000
   J% = 3
@@ -477,6 +477,8 @@ IF Y < 0 THEN Y = 0
 IF Y > 10 THEN Y = 10
 GOTO eventLoop"""
     )
+
+    private val defaultScript = EXAMPLES["HELLO.bas"]!!
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu_main, menu)

--- a/app/src/main/java/io/atha/bababasic/terminal/AndroidGraphicsRuntime.kt
+++ b/app/src/main/java/io/atha/bababasic/terminal/AndroidGraphicsRuntime.kt
@@ -127,8 +127,8 @@ class AndroidGraphicsRuntime(val stdio: BBUIFile) : GraphicsRuntime {
     }
 
     override fun inkeydlr(symbolTable: SymbolTable?, instruction: IR.Instruction?) {
-        val key: String = stdio.takeInputChar()
-        symbolTable!![instruction!!.result]!!.value!!.string = key
+        val key = stdio.takeInputChar()
+        symbolTable!![instruction!!.result]!!.value!!.string = key?.toString() ?: ""
     }
 
     override fun loadwav(

--- a/bbasic/src/main/java/io/atha/bbasic/awt/SystemInputOutputFile.kt
+++ b/bbasic/src/main/java/io/atha/bbasic/awt/SystemInputOutputFile.kt
@@ -25,8 +25,8 @@ class SystemInputOutputFile(
         return readLine()
     }
 
-    override fun takeInputChar(): String {
-        return ""
+    override fun takeInputChar(): Char? {
+        return null
     }
 
     override fun outputText(text: String) {

--- a/libbababasic/src/main/java/io/atha/libbababasic/file/BBFile.kt
+++ b/libbababasic/src/main/java/io/atha/libbababasic/file/BBFile.kt
@@ -13,6 +13,9 @@ interface BBFile {
     fun readLine(): String?
     fun readBytes(n: Int): ByteArray?
     fun print(s: String)
+    fun writeCodepoint(c: Int) {
+        c.toChar().toString().toByteArray(Charsets.UTF_8).forEach { writeByte(it) }
+    }
     fun writeByte(b: Byte)
     fun eof(): Boolean
     fun put(recordNumber: Int, symbolTable: SymbolTable)

--- a/libbababasic/src/main/java/io/atha/libbababasic/file/BBUIFile.kt
+++ b/libbababasic/src/main/java/io/atha/libbababasic/file/BBUIFile.kt
@@ -2,6 +2,6 @@ package io.atha.libbababasic.file
 
 interface BBUIFile : BBFile {
     fun inputDialog(prompt: String): String?
-    fun takeInputChar(): String
+    fun takeInputChar(): Char?
     fun outputText(text: String)
 }

--- a/libbababasic/src/main/java/io/atha/libbababasic/file/SystemInputOutputFile.kt
+++ b/libbababasic/src/main/java/io/atha/libbababasic/file/SystemInputOutputFile.kt
@@ -24,8 +24,8 @@ class SystemInputOutputFile(
         return readLine()
     }
 
-    override fun takeInputChar(): String {
-        return ""
+    override fun takeInputChar(): Char? {
+        return null
     }
 
     override fun outputText(text: String) {

--- a/libbababasic/src/main/java/io/atha/libbababasic/runtime/PrintBuffer.kt
+++ b/libbababasic/src/main/java/io/atha/libbababasic/runtime/PrintBuffer.kt
@@ -3,7 +3,7 @@ package io.atha.libbababasic.runtime
 import io.atha.libbababasic.file.BBFile
 
 class PrintBuffer {
-    private val buffer: MutableList<Byte> = mutableListOf()
+    private val buffer: MutableList<Int> = mutableListOf()
     private var cursor = 0
 
     fun appendAtCursor(value: String) {
@@ -11,13 +11,13 @@ class PrintBuffer {
             buffer.add(SPACE)
         }
         for (element in value) {
-            buffer[cursor++] = element.code.toByte()
+            buffer[cursor++] = element.code
         }
     }
 
     fun flush(file: BBFile) {
         for (i in buffer.indices) {
-            file.writeByte(buffer[i])
+            file.writeCodepoint(buffer[i])
         }
         for (i in buffer.indices) {
             buffer[i] = SPACE
@@ -27,6 +27,6 @@ class PrintBuffer {
     }
 
     companion object {
-        private const val SPACE = ' '.code.toByte()
+        private const val SPACE = ' '.code
     }
 }


### PR DESCRIPTION
Change STDIO to use UTF-8 to represent strings.

My goal in this is to make backwards-compatible changes to QBasic 4.5 as to support Unicode strings / UTF-8.

As Python 3 teaches us, this is a can of worms, so don't expect this to work consistently, or for advanced use-cases, although I'll try...

This fixes #60.